### PR TITLE
add second sorting to fit logic

### DIFF
--- a/static/js/page.js
+++ b/static/js/page.js
@@ -130,10 +130,13 @@ function scrollToTop() {
 // 刷新个人表
 function flush_self(sort_by = 'win_rate', desc = true) {
     const hero_array = Array.from(hero_dict.values());
+    let second_sort_by = sort_by == 'win_rate' ? 'scores' : 'win_rate';
     if (desc) {
+        hero_array.sort((hero1, hero2) => hero2[second_sort_by] - hero1[second_sort_by]);
         hero_array.sort((hero1, hero2) => hero2[sort_by] - hero1[sort_by]);
     }
     else {
+        hero_array.sort((hero1, hero2) => hero1[second_sort_by] - hero2[second_sort_by]);
         hero_array.sort((hero1, hero2) => hero1[sort_by] - hero2[sort_by]);
     }
 


### PR DESCRIPTION
个人榜可以根据胜率和得分分别排序，在主排序前应用次排序以合乎习惯。举例来说，修改使得按照胜率排名时，相等胜率但得分更高的会排序较高。